### PR TITLE
Update README with Specific File Requirements and Enhance Conda Environments

### DIFF
--- a/codes/diffusion_sd1/stable-diffusion/environment.yaml
+++ b/codes/diffusion_sd1/stable-diffusion/environment.yaml
@@ -10,6 +10,13 @@ dependencies:
   - torchvision=0.12.0
   - numpy=1.19.2
   - pip:
+    - pandas==2.0.3
+    - nibabel==5.1.0
+    - h5py==3.9.0
+    - matplotlib==3.7.2
+    - pycocotools==2.0.6
+    - ipython==8.12.2
+    - himalaya==0.4.2
     - albumentations==0.4.3
     - diffusers
     - opencv-python==4.1.2.30
@@ -29,3 +36,4 @@ dependencies:
     - -e git+https://github.com/CompVis/taming-transformers.git@master#egg=taming-transformers
     - -e git+https://github.com/openai/CLIP.git@main#egg=clip
     - -e .
+    - ../../gan/bdpy

--- a/codes/diffusion_sd2/stablediffusion/environment.yaml
+++ b/codes/diffusion_sd2/stablediffusion/environment.yaml
@@ -1,4 +1,4 @@
-name: ldm
+name: ldm2
 channels:
   - pytorch
   - defaults


### PR DESCRIPTION
Included in this PR:
- Adds a list of the required NSD dataset files in README. The full NSD dataset is ~8.3 TB so this helps save time.
- Adds all required python packages for running all steps (except Reconstruction with Decoded Text Prompt + GAN + Decoded Depth) to the conda env at codes\diffusion_sd1\stable-diffusion\environment.yaml and updates the README with this info.
- Renames the ldm conda env at codes\diffusion_sd2\stable-diffusion\environment.yaml to ldm2 so that the other ldm conda env doesn't have to be removed before creating this one
- Fixes a typo in README where img2feat_sd1.py should be img2feat_sd.py (the other file doesn't exist)